### PR TITLE
fix: use gh token for cloning

### DIFF
--- a/.github/workflows/deploy-solution.yml
+++ b/.github/workflows/deploy-solution.yml
@@ -30,6 +30,7 @@ jobs:
           build-environment: development
           deploy-environment: development
           dependency-token: ${{ secrets.THCARE_NODE_AUTH_TOKEN }}
+          clone-token: ${{ secrets.GITHUB_TOKEN }}
           solution-package: ${{ steps.package.outputs.filename }}
           azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
           azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}


### PR DESCRIPTION
the node token only has package permissions
and the gh token can be used for cloning,
hopefully.

TC-17
