### PR TITLE
fix: devcontainer lifecycle in codespace

### DIFF
--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-npm install

--- a/README.md
+++ b/README.md
@@ -4,8 +4,20 @@ Welcome to YOUR th.care framework powered Solution!
 
 ## Quickstart
 
+### Start a codespace
+
 The fastest way to get started is to spin up a codespace by clicking this button.
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/thcare/solution-template)
 
 Click that, and you'll get a new browser tab running VS Code with this readme open. See you on the other side!
+
+### Initialise your development environment
+
+In the VS Code [terminal](https://code.visualstudio.com/docs/terminal/basics) you can now run the following command:
+
+```
+npm run codespace:init
+```
+
+This will download some dependencies and prepare you to begin development of your solution.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
   "scripts": {
+    "codespace:init": "./src/scripts/codespace-init.sh",
     "prebuild": "npm run clean",
     "build": "src/scripts/build.sh",
     "prepare": "husky install",

--- a/src/scripts/codespace-init.sh
+++ b/src/scripts/codespace-init.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
+npm install
+
 cd /workspaces
 sudo -E git clone https://github.com/thcare/web.th.care.git
 sudo -E git clone https://github.com/thcare/api.th.care.git
 sudo chown -R node:node web.th.care api.th.care
+
+cd /workspaces/web.th.care
+sudo -E npm install
+
+cd /workspaces/api.th.care
+sudo -E npm install
+


### PR DESCRIPTION
The lifecycle events for devcontainers do not appear to fire in codespac

This addresses that and adds a simple command to get started.