### PR TITLE
fix: thfx CLI fails to install

### DIFF
--- a/src/scripts/codespace-init.sh
+++ b/src/scripts/codespace-init.sh
@@ -12,4 +12,5 @@ npm install
 cd ../api.th.care
 npm install
 
+cp .npmrc ~/
 npm install -g @thcare/thcarefx


### PR DESCRIPTION
Adds a global .npmrc for accessing the private registry.

TC-17