### PR TITLE
chore: `yarn dev` is not a service

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     },
     "dev": {
       "command": "thfx solution:dev",
-      "service": true,
       "dependencies": [
         "build",
         "start"


### PR DESCRIPTION
For reference, see this change in `thfx`: https://github.com/thcare/thfx/pull/691#discussion_r1362821836