### PR TITLE
feat: update .gitignore to ignore .thfx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ appsettings.json
 .wireit/
 
 src/generated/*
+
+# thfx 
+.thfx


### PR DESCRIPTION
The output of `thfx solution:bundle` will go here by default